### PR TITLE
Ensure enough of Rails is loaded to appease recent changes to Jammit

### DIFF
--- a/lib/guard/jammit.rb
+++ b/lib/guard/jammit.rb
@@ -9,6 +9,7 @@ module Guard
       super
       
       # init stuff here, thx!
+      ::Jammit.load_configuration ::Jammit::DEFAULT_CONFIG_PATH
     end
 
     # ================
@@ -48,8 +49,8 @@ module Guard
     
     def jammit
       ensure_rails_env!
-      ::Jammit.load_configuration ::Jammit::DEFAULT_CONFIG_PATH
-      puts "Jamming"
+      ::Jammit.reload!
+      puts "Jamming assets..."
       ::Jammit.packager.force = true
       ::Jammit.packager.precache_all
       true

--- a/lib/guard/jammit.rb
+++ b/lib/guard/jammit.rb
@@ -1,6 +1,7 @@
 require 'guard'
 require 'guard/guard'
 require 'jammit'
+
 module Guard
   class Jammit < Guard
 
@@ -46,6 +47,7 @@ module Guard
     end
     
     def jammit
+      ensure_rails_env!
       ::Jammit.load_configuration ::Jammit::DEFAULT_CONFIG_PATH
       puts "Jamming"
       ::Jammit.packager.force = true
@@ -53,5 +55,11 @@ module Guard
       true
     end
 
+    private
+    def ensure_rails_env!
+      if !defined?(::Rails) || !::Rails.respond_to?(:env)
+        require 'rails'
+      end
+    end
   end
 end


### PR DESCRIPTION
Jammit now checks `Rails.env` first when processing. If any other guards or Bundler (if you're using it) create the initial `Rails` module, but don't actually load `railties/lib/rails`, Jammit fails hard. This ensures that, if you're using enough of Rails in your Guardfile and are also using Jammit, that the rest of the necessary parts of Rails are loaded for Jammit to work.
