### PR TITLE
Support for custom configs

### DIFF
--- a/lib/guard/jammit.rb
+++ b/lib/guard/jammit.rb
@@ -47,10 +47,10 @@ module Guard
     def jammit
       begin
         ::Jammit.load_configuration @options[:config] || ::Jammit::DEFAULT_CONFIG_PATH
+        ::Guard::UI.info("Jamming #{@options[:config]}")
+        ::Guard::Notifier.notify("Jamming #{@options[:config]}", :title => 'Jammit')
         ::Jammit.packager.force = true
         ::Jammit.packager.precache_all
-        ::Guard::UI.info('Jamming')
-        ::Guard::Notifier.notify('Jamming', :title => 'Jammit')
         true
       rescue Exception => e
         ::Guard::UI.error("Jammit failed (#{e})")

--- a/lib/guard/jammit.rb
+++ b/lib/guard/jammit.rb
@@ -49,11 +49,11 @@ module Guard
         ::Jammit.load_configuration @options[:config] || ::Jammit::DEFAULT_CONFIG_PATH
         ::Jammit.packager.force = true
         ::Jammit.packager.precache_all
-        ::Guard::Notifier.info('Jamming')
+        ::Guard::UI.info('Jamming')
         ::Guard::Notifier.notify('Jamming', :title => 'Jammit')
         true
       rescue Exception => e
-        ::Guard::Notifier.error("Jammit failed (#{e})")
+        ::Guard::UI.error("Jammit failed (#{e})")
         ::Guard::Notifier.notify('Jammit failed', :title => 'Jammit', :image => :failed)
         false
       end

--- a/lib/guard/jammit.rb
+++ b/lib/guard/jammit.rb
@@ -45,11 +45,18 @@ module Guard
     end
     
     def jammit
-      ::Jammit.load_configuration @options[:config] || ::Jammit::DEFAULT_CONFIG_PATH
-      puts "Jamming"
-      ::Jammit.packager.force = true
-      ::Jammit.packager.precache_all
-      true
+      begin
+        ::Jammit.load_configuration @options[:config] || ::Jammit::DEFAULT_CONFIG_PATH
+        ::Jammit.packager.force = true
+        ::Jammit.packager.precache_all
+        ::Guard::Notifier.info('Jamming')
+        ::Guard::Notifier.notify('Jamming', :title => 'Jammit')
+        true
+      rescue Exception => e
+        ::Guard::Notifier.error("Jammit failed (#{e})")
+        ::Guard::Notifier.notify('Jammit failed', :title => 'Jammit', :image => :failed)
+        false
+      end
     end
 
   end

--- a/lib/guard/jammit.rb
+++ b/lib/guard/jammit.rb
@@ -6,8 +6,7 @@ module Guard
 
     def initialize(watchers = [], options = {})
       super
-      
-      # init stuff here, thx!
+      @options.merge(options)
     end
 
     # ================
@@ -46,7 +45,7 @@ module Guard
     end
     
     def jammit
-      ::Jammit.load_configuration ::Jammit::DEFAULT_CONFIG_PATH
+      ::Jammit.load_configuration @options[:config] || ::Jammit::DEFAULT_CONFIG_PATH
       puts "Jamming"
       ::Jammit.packager.force = true
       ::Jammit.packager.precache_all


### PR DESCRIPTION
Example usage:

```
guard 'jammit' do
  watch(%r{^public/js/.+\.js$})
  watch(%r{^public/css/.+\.css$})
end

guard 'jammit', :config => 'config/assets.production.yml' do
  watch("public/assets/application.js")
  watch("public/assets/site.css")
end
```
